### PR TITLE
Release sebex_test_y v0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ by adding `sebex_test_y` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-	{:sebex_test_y, "~> 0.7.0"}
+	{:sebex_test_y, "~> 0.8.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule SebexTestY.MixProject do
   use Mix.Project
 
-  @version "0.7.0"
+  @version "0.8.0"
 
   def project do
     [
@@ -24,7 +24,7 @@ defmodule SebexTestY.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:sebex_test_x, "~> 0.8.0", organization: "membraneframework_labs"},
+      {:sebex_test_x, "~> 0.9.0", organization: "membraneframework_labs"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}
     ]
   end


### PR DESCRIPTION
### Release "Unduly Sure Shrimp"

| Project | New Version |
|---|---|
| sebex_test_core | `0.6.0` |
| sebex_test_x | `0.9.0` |
| sebex_test_f | `0.3.0` |


<sup>proudly automated with <a href="https://github.com/membraneframework/sebex">Sebex</a></sup>